### PR TITLE
Add graphviz to webapp Docker image

### DIFF
--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -10,7 +10,7 @@ ENV REACT_APP_API_URI=$API_URI
 #Create an optimized version of the webapp
 RUN npm run build
 #Install software neccesary for generating the doc
-RUN apt-get update && apt-get -y install ruby openjdk-8-jre
+RUN apt-get update && apt-get -y install ruby openjdk-8-jre graphviz
 RUN gem install asciidoctor asciidoctor-diagram
 RUN npm install shx --save-dev
 #Generate the doc


### PR DESCRIPTION
Graphviz is necessary to create the diagrams
with plantuml.