### PR TITLE
Use sh (ash) instead of bash in prometheus entrypoint

### DIFF
--- a/restapi/monitoring/prometheus/Dockerfile
+++ b/restapi/monitoring/prometheus/Dockerfile
@@ -1,4 +1,4 @@
 FROM prom/prometheus
 ADD ./heroku/prometheus.yml /etc/prometheus/
 ADD heroku-run.sh /
-ENTRYPOINT ["bash /heroku-run.sh"]
+ENTRYPOINT ["sh /heroku-run.sh"]


### PR DESCRIPTION
After testing locally with a prometheus container I noticed that I had to attach with ash or sh, but not bash as it is not installed in the base image that prometheus uses.